### PR TITLE
ci: add explicit permissions to release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,14 @@ on:
       - 'main'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release-version: ${{ steps.semantic.outputs.release-version }}
       new-release-published: ${{ steps.semantic.outputs.new-release-published }}


### PR DESCRIPTION
Fixes the CodeQL "Workflow does not contain permissions" alert by adding a least-privilege top-level `permissions` block (`contents: read`) and granting the `semantic-release` job `contents: write` for creating releases/tags.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUBMH8FcdYqF9kX4XhjStA)_